### PR TITLE
feat: 핀 api 연결 - #36 

### DIFF
--- a/src/components/dashboard/project/ProjectCard.tsx
+++ b/src/components/dashboard/project/ProjectCard.tsx
@@ -18,7 +18,7 @@ const ProjectCard = ({
   people,
   updatedAt,
   startDate,
-  externalId,
+  id,
 }: ProjectCardProps) => {
   // 시간을 '~분 전'과 같은 읽기 쉬운 형식으로 변환
 
@@ -161,7 +161,7 @@ const ProjectCard = ({
               <div className="absolute bottom-[11%] right-[7%] opacity-0 group-hover:opacity-100 transition-all duration-200">
                 <Link
                   className="w-10 h-10 rounded-full bg-[var(--fill-deep,#3B4553)] flex items-center justify-center cursor-pointer"
-                  to={`/plan/${externalId}`}
+                  to={`/plan/${id}`}
                 >
                   <ArrowRight className="w-5 h-5 text-white" />
                 </Link>

--- a/src/components/dashboard/project/ProjectSection.tsx
+++ b/src/components/dashboard/project/ProjectSection.tsx
@@ -18,7 +18,11 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects }) => {
   const sortOptions = ["최근 수정한 순", "최근 생성한 순", "이름순"];
   const teamOptions = [
     "모든 팀",
-    ...(projects ? Array.from(new Set(projects.filter(p => p.team).map((p) => p.team.teamName))).sort() : []),
+    ...(projects
+      ? Array.from(
+          new Set(projects.filter((p) => p.team).map((p) => p.team.teamName))
+        ).sort()
+      : []),
   ];
 
   // 경로나 팀 ID가 변경될 때 필터 상태 업데이트
@@ -46,10 +50,13 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects }) => {
 
   // 선택된 팀과 정렬 기준에 따라 프로젝트 필터링 및 정렬
   const filteredProjects = React.useMemo(() => {
-    const filtered = projects ? projects.filter(
-      (project) =>
-        selectedTeam === "모든 팀" || (project.team && project.team.teamName === selectedTeam)
-    ) : [];
+    const filtered = projects
+      ? projects.filter(
+          (project) =>
+            selectedTeam === "모든 팀" ||
+            (project.team && project.team.teamName === selectedTeam)
+        )
+      : [];
 
     return filtered.sort((a: Project, b: Project) => {
       switch (sortBy) {

--- a/src/components/plan/map/InfoOverlay.tsx
+++ b/src/components/plan/map/InfoOverlay.tsx
@@ -3,8 +3,8 @@ import ColorTextBtn from "../../common/ColorTextBtn";
 import { useFavoriteStore } from "../../../stores/useFavoriteStore";
 import { useSpotCollectionStore } from "../../../stores/useSpotCollectionStore";
 import { getCategoryIcon } from "../../../utils/categoryUtils";
-import usePostPin from "../../../hooks/usePostPin";
 import useAuthStore from "../../../stores/useAuthStore";
+import usePostPin from "../../../hooks/plan/usePostPin";
 
 interface InfoOverlayProps {
   clickedPlace: {

--- a/src/components/plan/map/InfoOverlay.tsx
+++ b/src/components/plan/map/InfoOverlay.tsx
@@ -5,6 +5,7 @@ import { useSpotCollectionStore } from "../../../stores/useSpotCollectionStore";
 import { getCategoryIcon } from "../../../utils/categoryUtils";
 import useAuthStore from "../../../stores/useAuthStore";
 import usePostPin from "../../../hooks/plan/usePostPin";
+import useDeletePin from "../../../hooks/plan/useDeletePin";
 
 interface InfoOverlayProps {
   clickedPlace: {
@@ -16,7 +17,8 @@ interface InfoOverlayProps {
 }
 
 const InfoOverlay = ({ clickedPlace, onClose }: InfoOverlayProps) => {
-  const { toggleFavorite, isFavorite } = useFavoriteStore();
+  const { isFavorite, addFavorite, removeFavorite, getFavorite } =
+    useFavoriteStore();
   const { addToCollection, isInCollection } = useSpotCollectionStore();
   const { postPin } = usePostPin();
 
@@ -24,22 +26,31 @@ const InfoOverlay = ({ clickedPlace, onClose }: InfoOverlayProps) => {
   const isFavorited = isFavorite(placeId);
   const isCollected = isInCollection(placeId);
   const email = useAuthStore.getState().email;
+  const { deletePin } = useDeletePin();
 
-  const handleFavoriteClick = (e: React.MouseEvent) => {
+  const handleFavoriteClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    postPin({
-      name: clickedPlace.place.place_name || "",
-      address:
-        clickedPlace.place.road_address_name ||
-        clickedPlace.place.address_name ||
-        "",
-      latitude: Number(clickedPlace.place.y),
-      longitude: Number(clickedPlace.place.x),
-      detailLink: `https://place.map.kakao.com/${placeId}`,
-      category: clickedPlace.place.category_group_name || "기타",
-      author: email || "",
-    });
-    toggleFavorite(clickedPlace.place);
+    if (isFavorited) {
+      const favorite = getFavorite(placeId);
+      if (favorite) {
+        await deletePin(favorite.id);
+        removeFavorite(favorite.id);
+      }
+    } else {
+      const postPinId = await postPin({
+        name: clickedPlace.place.place_name || "",
+        address:
+          clickedPlace.place.road_address_name ||
+          clickedPlace.place.address_name ||
+          "",
+        latitude: Number(clickedPlace.place.y),
+        longitude: Number(clickedPlace.place.x),
+        detailLink: `https://place.map.kakao.com/${placeId}`,
+        category: clickedPlace.place.category_group_name || "기타",
+        author: email || "",
+      });
+      postPinId && addFavorite(clickedPlace.place, postPinId);
+    }
   };
 
   const handleDetailClick = () => {

--- a/src/components/plan/map/InfoOverlay.tsx
+++ b/src/components/plan/map/InfoOverlay.tsx
@@ -21,6 +21,7 @@ const InfoOverlay = ({ clickedPlace, onClose }: InfoOverlayProps) => {
     useFavoriteStore();
   const { addToCollection, isInCollection } = useSpotCollectionStore();
   const { postPin } = usePostPin();
+  // TODO: postPin 에러 처리
 
   const placeId = clickedPlace.place.id;
   const isFavorited = isFavorite(placeId);

--- a/src/components/plan/map/InfoOverlay.tsx
+++ b/src/components/plan/map/InfoOverlay.tsx
@@ -3,6 +3,8 @@ import ColorTextBtn from "../../common/ColorTextBtn";
 import { useFavoriteStore } from "../../../stores/useFavoriteStore";
 import { useSpotCollectionStore } from "../../../stores/useSpotCollectionStore";
 import { getCategoryIcon } from "../../../utils/categoryUtils";
+import usePostPin from "../../../hooks/usePostPin";
+import useAuthStore from "../../../stores/useAuthStore";
 
 interface InfoOverlayProps {
   clickedPlace: {
@@ -16,13 +18,27 @@ interface InfoOverlayProps {
 const InfoOverlay = ({ clickedPlace, onClose }: InfoOverlayProps) => {
   const { toggleFavorite, isFavorite } = useFavoriteStore();
   const { addToCollection, isInCollection } = useSpotCollectionStore();
+  const { postPin } = usePostPin();
 
   const placeId = clickedPlace.place.id;
   const isFavorited = isFavorite(placeId);
   const isCollected = isInCollection(placeId);
+  const email = useAuthStore.getState().email;
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    postPin({
+      name: clickedPlace.place.place_name || "",
+      address:
+        clickedPlace.place.road_address_name ||
+        clickedPlace.place.address_name ||
+        "",
+      latitude: Number(clickedPlace.place.y),
+      longitude: Number(clickedPlace.place.x),
+      detailLink: `https://place.map.kakao.com/${placeId}`,
+      category: clickedPlace.place.category_group_name || "기타",
+      author: email || "",
+    });
     toggleFavorite(clickedPlace.place);
   };
 

--- a/src/components/plan/map/MapSection.tsx
+++ b/src/components/plan/map/MapSection.tsx
@@ -1,5 +1,5 @@
 import { Map, CustomOverlayMap, useKakaoLoader } from "react-kakao-maps-sdk";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import SearchBar from "./SearchBar";
 import getDistance from "../../../utils/getDistance";
 import BasePin from "./BasePin";
@@ -7,6 +7,7 @@ import InfoOverlay from "./InfoOverlay";
 import { useFavoriteStore } from "../../../stores/useFavoriteStore";
 import FavoritePin from "./FavoritePin";
 import CategoryFilterBtns from "../CategoryFilterBtns";
+import useGetPins from "../../../hooks/plan/useGetPins";
 
 const MapSection = () => {
   const [loading, error] = useKakaoLoader({
@@ -22,7 +23,7 @@ const MapSection = () => {
   const [searchResults, setSearchResults] = useState<
     kakao.maps.services.PlacesSearchResultItem[]
   >([]);
-  const { favorites } = useFavoriteStore();
+  const { favorites, addAllFavorites } = useFavoriteStore();
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const categories = [
     "MT1", // 대형마트
@@ -44,8 +45,14 @@ const MapSection = () => {
     "HP8", // 병원
     "PM9", // 약국
   ] as const;
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>지도 로딩 중 오류 발생</div>;
+  const { pins, loading: pinsLoading, error: pinsError } = useGetPins();
+
+  useEffect(() => {
+    addAllFavorites(pins);
+  }, [pins]);
+
+  if (loading || pinsLoading) return <div>Loading...</div>;
+  if (error || pinsError) return <div>지도 로딩 중 오류 발생</div>;
   const ps = new kakao.maps.services.Places();
 
   const handleSearchSubmit = (keyword: string) => {

--- a/src/hooks/plan/useDeletePin.ts
+++ b/src/hooks/plan/useDeletePin.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import baseService from "../../service/baseService";
+
+const useDeletePin = () => {
+  const projectId = useParams().id;
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const deletePin = async (pinId: string) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await baseService.delete(
+        `/v1/projects/${projectId}/pins/${pinId}`
+      );
+      return response.data;
+    } catch (error) {
+      console.error("핀 삭제 실패:", error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+  return { deletePin, loading, error };
+};
+
+export default useDeletePin;

--- a/src/hooks/plan/useDeletePin.ts
+++ b/src/hooks/plan/useDeletePin.ts
@@ -6,6 +6,7 @@ const useDeletePin = () => {
   const projectId = useParams().id;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // TODO: projectId 없을 시 에러 처리
   const deletePin = async (pinId: string) => {
     try {
       setLoading(true);

--- a/src/hooks/plan/useGetPins.ts
+++ b/src/hooks/plan/useGetPins.ts
@@ -14,6 +14,7 @@ const useGetPins = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { id: projectId } = useParams<{ id: string }>();
+  // TODO: projectId 없을 시 에러 처리
 
   const fetchPins = useCallback(async () => {
     if (!projectId) return;

--- a/src/hooks/plan/useGetPins.ts
+++ b/src/hooks/plan/useGetPins.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from "react";
+import type { MapPin, MapPinResponse } from "../../types/planTypes";
+import { useParams } from "react-router-dom";
+import baseService from "../../service/baseService";
+
+interface GetPinsResponse {
+  data: MapPinResponse[];
+  message: string;
+  status: number;
+}
+
+const useGetPins = () => {
+  const [pins, setPins] = useState<MapPin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { id: projectId } = useParams<{ id: string }>();
+
+  const fetchPins = useCallback(async () => {
+    if (!projectId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await baseService.get(`/v1/projects/${projectId}/pins`);
+      const pinData = response.data as GetPinsResponse;
+      setPins(pinData.data.map((item) => item.place));
+    } catch (error) {
+      console.error("핀 데이터 로딩 실패:", error);
+      setError(error as string);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  // 컴포넌트 마운트 시 자동 로딩
+  useEffect(() => {
+    fetchPins();
+  }, [fetchPins]);
+
+  return {
+    pins,
+    loading,
+    error,
+    refetch: fetchPins, // 수동 새로고침용
+  };
+};
+
+export default useGetPins;

--- a/src/hooks/plan/usePostPin.ts
+++ b/src/hooks/plan/usePostPin.ts
@@ -16,6 +16,7 @@ const usePostPin = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const projectId = useParams().id;
+  // TODO: projectId 없을 시 에러 처리
   const postPin = async (pin: CreateMapPinRequest) => {
     try {
       setLoading(true);

--- a/src/hooks/plan/usePostPin.ts
+++ b/src/hooks/plan/usePostPin.ts
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import type { CreateMapPinRequest } from "../../types/planTypes";
+import type {
+  CreateMapPinRequest,
+  MapPinResponse,
+} from "../../types/planTypes";
 import baseService from "../../service/baseService";
 
 interface PinResponseType {
   status: number;
   message: string;
-  data: string;
+  data: MapPinResponse;
 }
 
 const usePostPin = () => {
@@ -21,8 +24,8 @@ const usePostPin = () => {
         `/v1/projects/${projectId}/pins`,
         pin
       );
-      console.log(response.data);
-      return response.data;
+      const data = response.data.data as MapPinResponse;
+      return data.id;
     } catch (error) {
       console.error(error);
       setError(error as string);

--- a/src/hooks/plan/usePostPin.ts
+++ b/src/hooks/plan/usePostPin.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import type { CreateMapPinRequest } from "../types/planTypes";
-import baseService from "../service/baseService";
 import { useParams } from "react-router-dom";
+import type { CreateMapPinRequest } from "../../types/planTypes";
+import baseService from "../../service/baseService";
 
 interface PinResponseType {
   status: number;

--- a/src/hooks/usePostPin.ts
+++ b/src/hooks/usePostPin.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import type { CreateMapPinRequest } from "../types/planTypes";
+import baseService from "../service/baseService";
+import { useParams } from "react-router-dom";
+
+interface PinResponseType {
+  status: number;
+  message: string;
+  data: string;
+}
+
+const usePostPin = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const projectId = useParams().id;
+  const postPin = async (pin: CreateMapPinRequest) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await baseService.post<PinResponseType>(
+        `/v1/projects/${projectId}/pins`,
+        pin
+      );
+      console.log(response.data);
+      return response.data;
+    } catch (error) {
+      console.error(error);
+      setError(error as string);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { postPin, loading, error };
+};
+
+export default usePostPin;

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -66,6 +66,7 @@ class AuthService {
       if (response.data) {
         const accessToken = response.data.data;
         useAuthStore.getState().setAccessToken(accessToken);
+        useAuthStore.getState().setEmail(credentials.email);
       }
 
       // refreshToken은 HTTP-only 쿠키로 자동 설정되므로 별도 처리 필요 없음

--- a/src/service/baseService.ts
+++ b/src/service/baseService.ts
@@ -2,15 +2,17 @@ import axios from "axios";
 import useAuthStore from "../stores/useAuthStore";
 
 // 개발 환경에서의 기본값 설정
-const URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+const URL = (import.meta.env.VITE_API_URL || "http://localhost:8080").replace(
+  /\/$/,
+  ""
+);
 
 // TypeScript와 Axios 호환성 문제 피하기 위해 일반 객체로 생성
 const baseService = axios.create({
+  baseURL: URL,
   withCredentials: true,
+  timeout: 15000, // 네트워크 hang 방지
 });
-
-// URL 직접 설정 (이렇게 하면 TypeScript 오류를 피할 수 있음)
-(baseService.defaults as any).baseURL = URL;
 
 // 인증이 필요없는 경로들 (토큰을 첨부하지 않아야 함)
 const nonAuthPaths = ["/v1/auth/signup", "/v1/auth/login", "/v1/auth/refresh"];

--- a/src/service/baseService.ts
+++ b/src/service/baseService.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import useAuthStore from "../stores/useAuthStore";
 
 // 개발 환경에서의 기본값 설정
-const URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:8080";
+const URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 // TypeScript와 Axios 호환성 문제 피하기 위해 일반 객체로 생성
 const baseService = axios.create({

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -4,8 +4,10 @@ import { persist } from "zustand/middleware";
 interface AuthState {
   isLoggedIn: boolean;
   accessToken: string | null;
+  email: string | null;
   setIsLoggedIn: (isLoggedIn: boolean) => void;
   setAccessToken: (token: string) => void;
+  setEmail: (email: string) => void;
   clearAuth: () => void;
 }
 
@@ -14,9 +16,13 @@ const useAuthStore = create<AuthState>()(
     (set) => ({
       isLoggedIn: false,
       accessToken: null,
+      email: null,
       setIsLoggedIn: (isLoggedIn: boolean) => set({ isLoggedIn }),
-      setAccessToken: (token: string) => set({ accessToken: token, isLoggedIn: !!token }),
-      clearAuth: () => set({ isLoggedIn: false, accessToken: null }),
+      setAccessToken: (token: string) =>
+        set({ accessToken: token, isLoggedIn: !!token }),
+      setEmail: (email: string) => set({ email }),
+      clearAuth: () =>
+        set({ isLoggedIn: false, accessToken: null, email: null }),
     }),
     {
       name: "auth-storage",

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import type { MapPin } from "../types/planTypes";
 
 interface FavoriteStore {
@@ -10,50 +9,43 @@ interface FavoriteStore {
   toggleFavorite: (place: kakao.maps.services.PlacesSearchResultItem) => void;
 }
 
-export const useFavoriteStore = create<FavoriteStore>()(
-  persist(
-    (set, get) => ({
-      favorites: [],
+export const useFavoriteStore = create<FavoriteStore>()((set, get) => ({
+  favorites: [],
 
-      addFavorite: (place) => {
-        const favoritePlace: MapPin = {
-          id: place.id || Date.now() + Math.random().toString(),
-          address: place.road_address_name || place.address_name || "",
-          latitude: Number(place.y),
-          longitude: Number(place.x),
-          detailLink: `https://place.map.kakao.com/${place.id}`,
-          author: "unknown",
-          category: place.category_group_name || "장소",
-        };
+  addFavorite: (place) => {
+    const favoritePlace: MapPin = {
+      id: place.id || Date.now() + Math.random().toString(),
+      address: place.road_address_name || place.address_name || "",
+      latitude: Number(place.y),
+      longitude: Number(place.x),
+      detailLink: `https://place.map.kakao.com/${place.id}`,
+      author: "unknown",
+      category: place.category_group_name || "장소",
+    };
 
-        set((state) => ({
-          favorites: [...state.favorites, favoritePlace],
-        }));
-      },
+    set((state) => ({
+      favorites: [...state.favorites, favoritePlace],
+    }));
+  },
 
-      removeFavorite: (placeId) => {
-        set((state) => ({
-          favorites: state.favorites.filter((fav) => fav.id !== placeId),
-        }));
-      },
+  removeFavorite: (placeId) => {
+    set((state) => ({
+      favorites: state.favorites.filter((fav) => fav.id !== placeId),
+    }));
+  },
 
-      isFavorite: (placeId) => {
-        return get().favorites.some((fav) => fav.id === placeId.toString());
-      },
+  isFavorite: (placeId) => {
+    return get().favorites.some((fav) => fav.id === placeId.toString());
+  },
 
-      toggleFavorite: (place) => {
-        const placeId = place.id || Date.now() + Math.random().toString();
-        const { isFavorite, addFavorite, removeFavorite } = get();
+  toggleFavorite: (place) => {
+    const placeId = place.id || Date.now() + Math.random().toString();
+    const { isFavorite, addFavorite, removeFavorite } = get();
 
-        if (isFavorite(placeId.toString())) {
-          removeFavorite(placeId.toString());
-        } else {
-          addFavorite(place);
-        }
-      },
-    }),
-    {
-      name: "favorite-places",
+    if (isFavorite(placeId.toString())) {
+      removeFavorite(placeId.toString());
+    } else {
+      addFavorite(place);
     }
-  )
-);
+  },
+}));

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -1,9 +1,11 @@
 import { create } from "zustand";
 import type { MapPin } from "../types/planTypes";
+import useAuthStore from "./useAuthStore";
 
 interface FavoriteStore {
   favorites: MapPin[];
   addFavorite: (place: kakao.maps.services.PlacesSearchResultItem) => void;
+  addAllFavorites: (places: MapPin[]) => void;
   removeFavorite: (placeId: string) => void;
   isFavorite: (placeId: string) => boolean;
   toggleFavorite: (place: kakao.maps.services.PlacesSearchResultItem) => void;
@@ -13,19 +15,26 @@ export const useFavoriteStore = create<FavoriteStore>()((set, get) => ({
   favorites: [],
 
   addFavorite: (place) => {
+    const email = useAuthStore.getState().email;
     const favoritePlace: MapPin = {
       id: place.id || Date.now() + Math.random().toString(),
       address: place.road_address_name || place.address_name || "",
       latitude: Number(place.y),
       longitude: Number(place.x),
       detailLink: `https://place.map.kakao.com/${place.id}`,
-      author: "unknown",
+      author: email || "",
       category: place.category_group_name || "장소",
       name: place.place_name || "",
     };
 
     set((state) => ({
       favorites: [...state.favorites, favoritePlace],
+    }));
+  },
+
+  addAllFavorites: (places) => {
+    set(() => ({
+      favorites: [...places],
     }));
   },
 

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -21,6 +21,7 @@ export const useFavoriteStore = create<FavoriteStore>()((set, get) => ({
       detailLink: `https://place.map.kakao.com/${place.id}`,
       author: "unknown",
       category: place.category_group_name || "장소",
+      name: place.place_name || "",
     };
 
     set((state) => ({

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -4,20 +4,23 @@ import useAuthStore from "./useAuthStore";
 
 interface FavoriteStore {
   favorites: MapPin[];
-  addFavorite: (place: kakao.maps.services.PlacesSearchResultItem) => void;
+  addFavorite: (
+    place: kakao.maps.services.PlacesSearchResultItem,
+    postPinId: string
+  ) => void;
   addAllFavorites: (places: MapPin[]) => void;
   removeFavorite: (placeId: string) => void;
   isFavorite: (placeId: string) => boolean;
-  toggleFavorite: (place: kakao.maps.services.PlacesSearchResultItem) => void;
+  getFavorite: (placeId: string) => MapPin | undefined;
 }
 
 export const useFavoriteStore = create<FavoriteStore>()((set, get) => ({
   favorites: [],
 
-  addFavorite: (place) => {
+  addFavorite: (place, postPinId) => {
     const email = useAuthStore.getState().email;
     const favoritePlace: MapPin = {
-      id: place.id || Date.now() + Math.random().toString(),
+      id: postPinId,
       address: place.road_address_name || place.address_name || "",
       latitude: Number(place.y),
       longitude: Number(place.x),
@@ -45,17 +48,14 @@ export const useFavoriteStore = create<FavoriteStore>()((set, get) => ({
   },
 
   isFavorite: (placeId) => {
-    return get().favorites.some((fav) => fav.id === placeId.toString());
+    return get().favorites.some(
+      (fav) => fav.detailLink.split("/").pop() === placeId.toString()
+    );
   },
 
-  toggleFavorite: (place) => {
-    const placeId = place.id || Date.now() + Math.random().toString();
-    const { isFavorite, addFavorite, removeFavorite } = get();
-
-    if (isFavorite(placeId.toString())) {
-      removeFavorite(placeId.toString());
-    } else {
-      addFavorite(place);
-    }
+  getFavorite: (placeId) => {
+    return get().favorites.find(
+      (fav) => fav.detailLink.split("/").pop() === placeId.toString()
+    );
   },
 }));

--- a/src/types/planTypes.ts
+++ b/src/types/planTypes.ts
@@ -10,6 +10,13 @@ export interface MapPin {
   author: string;
 }
 
+export interface MapPinResponse {
+  author: string;
+  id: string;
+  place: MapPin;
+  projectId: string;
+}
+
 // 지도 핀 생성 API 요청용
 export type CreateMapPinRequest = Omit<MapPin, "id">;
 

--- a/src/types/planTypes.ts
+++ b/src/types/planTypes.ts
@@ -1,6 +1,7 @@
 // 지도 핀
 export interface MapPin {
   id: string;
+  name: string;
   address: string;
   latitude: number;
   longitude: number;
@@ -8,6 +9,9 @@ export interface MapPin {
   category: string;
   author: string;
 }
+
+// 지도 핀 생성 API 요청용
+export type CreateMapPinRequest = Omit<MapPin, "id">;
 
 // 장소 블록
 export interface PlaceBlock {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,6 +1,7 @@
 import type { Team } from "./team";
 
 export interface Project {
+  id: string;
   externalId: string;
   title: string;
   description: string;


### PR DESCRIPTION
## 📌 PR 제목

feat: 핀 api 연결 - #36 

## 📍 PR 내용

지도에서 핀 추가, 핀 삭제, 핀 로드 구현했습니다.

## 📎 관련 이슈

- #36 

## 💡 테스트 방법

- 로그인 이후 새 프로젝트를 생성하여 그 프로젝트로 들어가 맵에서 핀을 찍고 새로고침도 하고 삭제도 해보십쇼

---

## 📷 스크린샷(선택)
<!-- 필요 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 지도에서 프로젝트 핀을 자동으로 불러와 즐겨찾기에 일괄 반영합니다.
  - 즐겨찾기 추가·삭제 시 서버에 핀을 생성/삭제해 실시간 동기화됩니다.
  - 핀 생성 시 로그인한 사용자의 이메일을 작성자 정보로 저장합니다.

- Improvements
  - 지도 화면의 로딩·에러 처리가 강화되어 안정성이 향상되었습니다.
  - 프로젝트 카드의 계획 페이지 이동 링크가 더 신뢰성 있게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->