### PR TITLE
feat: Plan 페이지 헤더 구현 - #49

### DIFF
--- a/src/components/plan/PlanHeader.tsx
+++ b/src/components/plan/PlanHeader.tsx
@@ -1,0 +1,21 @@
+import { ChevronLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+const PlanHeader: React.FC<{ projectName: string }> = ({ projectName }) => {
+  const navigate = useNavigate();
+  return (
+    <div className="flex items-center justify-between h-16 bg-white border-b border-gray-200 pl-9 pr-4 border-r border-b border-r-[#131416] border-r-[1.5px] border-b-[#131416] border-b-[1.5px] bg-[#e7edf6]">
+      <div className="flex items-center gap-3">
+        <ChevronLeft
+          size={24}
+          color="#3b4553"
+          onClick={() => navigate(-1)}
+          className="cursor-pointer"
+        />
+        <h1 className="text-xl font-semibold text-gray-800">{projectName}</h1>
+      </div>
+    </div>
+  );
+};
+
+export default PlanHeader;

--- a/src/components/plan/header/LeftSide.tsx
+++ b/src/components/plan/header/LeftSide.tsx
@@ -1,0 +1,21 @@
+import { ChevronLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+const LeftSide: React.FC<{ projectName: string }> = ({ projectName }) => {
+  const navigate = useNavigate();
+  return (
+    <div className="flex items-center gap-3">
+      <ChevronLeft
+        size={24}
+        color="#3b4553"
+        onClick={() => navigate(-1)}
+        className="cursor-pointer"
+      />
+      <h1 className="text-xl font-semibold text-[#131416] tracking-[-0.4px]">
+        {projectName}
+      </h1>
+    </div>
+  );
+};
+
+export default LeftSide;

--- a/src/components/plan/header/PlanHeader.tsx
+++ b/src/components/plan/header/PlanHeader.tsx
@@ -1,0 +1,13 @@
+import LeftSide from "./LeftSide";
+import RightSide from "./RightSide";
+
+const PlanHeader: React.FC<{ projectName: string }> = ({ projectName }) => {
+  return (
+    <div className="flex items-center justify-between h-16 bg-white border-b border-gray-200 pl-9 pr-4 border-r border-b border-r-[#131416] border-r-[1.5px] border-b-[#131416] border-b-[1.5px] bg-[#e7edf6]">
+      <LeftSide projectName={projectName} />
+      <RightSide />
+    </div>
+  );
+};
+
+export default PlanHeader;

--- a/src/components/plan/header/RightSide.tsx
+++ b/src/components/plan/header/RightSide.tsx
@@ -1,0 +1,17 @@
+import UserSection from "./UserSection";
+
+const RightSide = () => {
+  return (
+    <div className="flex items-center gap-3">
+      <UserSection />
+      <button
+        className="px-3 h-9 flex justify-center items-center rounded-[6px] bg-[#4f5fbf] text-[#fff] text-base font-semibold hover:bg-[#4253b1] cursor-pointer"
+        onClick={() => alert("구현되지 않은 기능입니다.")}
+      >
+        초대하기
+      </button>
+    </div>
+  );
+};
+
+export default RightSide;

--- a/src/components/plan/header/UserSection.tsx
+++ b/src/components/plan/header/UserSection.tsx
@@ -1,0 +1,19 @@
+import useGetLiveMember from "../../../hooks/member/useGetLiveMember";
+
+const UserSection = () => {
+  const { liveMember, isLoading, error } = useGetLiveMember();
+
+  //TODO: LiveMember 리스트 출력하기
+
+  if (!isLoading && !error) {
+    return (
+      <div className="flex items-center gap-2">
+        {liveMember.map((member) => (
+          <div key={member.id}>{member.name}</div>
+        ))}
+      </div>
+    );
+  }
+};
+
+export default UserSection;

--- a/src/hooks/member/useGetLiveMember.ts
+++ b/src/hooks/member/useGetLiveMember.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import baseService from "../../service/baseService";
+
+interface LiveMember {
+  id: string;
+  email: string;
+  name: string;
+  profileImage: string;
+}
+
+interface LiveMemberResponse {
+  data: LiveMember[];
+  status: number;
+  message: string;
+}
+
+const useGetLiveMember = () => {
+  const [liveMember, setLiveMember] = useState<LiveMember[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const projectId = useParams().id;
+
+  const getLiveMember = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await baseService.get<LiveMemberResponse>(
+        `/v1/projects/${projectId}/members`
+      );
+
+      setLiveMember(response.data.data);
+    } catch (error) {
+      setError(error as string);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    getLiveMember();
+  }, [getLiveMember]);
+
+  return { liveMember, isLoading, error, getLiveMember };
+};
+
+export default useGetLiveMember;

--- a/src/hooks/project/useGetProjectInfo.ts
+++ b/src/hooks/project/useGetProjectInfo.ts
@@ -1,0 +1,48 @@
+import { useParams } from "react-router-dom";
+import type { Project } from "../../types/project";
+import { useCallback, useEffect, useState } from "react";
+import baseService from "../../service/baseService";
+
+interface ProjectInfoResponse {
+  data: {
+    project: Project;
+  };
+  status: number;
+  message: string;
+}
+
+const useGetProjectInfo = () => {
+  const [projectInfo, setProjectInfo] = useState<Project | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const projectId = useParams().id;
+
+  const getProjectInfo = useCallback(async () => {
+    if (!projectId) {
+      setError("프로젝트 ID가 없습니다.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await baseService.get<ProjectInfoResponse>(
+        `/v1/projects/${projectId}`
+      );
+      setProjectInfo(response.data.data.project);
+    } catch (error) {
+      console.error("프로젝트 정보 조회 실패", error);
+      setError(error as string);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    getProjectInfo();
+  }, [getProjectInfo]);
+
+  return { projectInfo, isLoading, error, getProjectInfo };
+};
+
+export default useGetProjectInfo;

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,6 +1,6 @@
 import MapSection from "../components/plan/map/MapSection";
 import CommentSheet from "../components/plan/modal/CommentSheet";
-import PlanHeader from "../components/plan/PlanHeader";
+import PlanHeader from "../components/plan/header/PlanHeader";
 import SpotCollectionBoard from "../components/plan/spotCollection/SpotCollectionBoard";
 import useGetProjectInfo from "../hooks/project/useGetProjectInfo";
 import { useModalStore } from "../stores/useModalStore";

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,55 +1,20 @@
 import MapSection from "../components/plan/map/MapSection";
 import CommentSheet from "../components/plan/modal/CommentSheet";
+import PlanHeader from "../components/plan/PlanHeader";
 import SpotCollectionBoard from "../components/plan/spotCollection/SpotCollectionBoard";
+import useGetProjectInfo from "../hooks/project/useGetProjectInfo";
 import { useModalStore } from "../stores/useModalStore";
 
 const Plan = () => {
-  const {
-    activeModal,
-    openCommentModal,
-    openCreateGroupModal,
-    openModifyGroupModal,
-  } = useModalStore();
+  const { activeModal } = useModalStore();
+  const { projectInfo } = useGetProjectInfo();
+
   return (
     <div className="flex w-full h-screen bg-gray-100 overflow-hidden">
       {/* 좌측 영역 (헤더 + 좌측 패널 + 중간 패널) */}
       <div className="flex flex-col w-[57.292%]">
         {/* 상단 헤더 - 좌측 패널과 중간 패널을 통과 */}
-        <div className="flex items-center justify-between h-16 bg-white border-b border-gray-200 px-6">
-          <h1 className="text-xl font-semibold text-gray-800">프로젝트 이름</h1>
-          <div className="flex items-center space-x-4">
-            <button className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors">
-              초대하기
-            </button>
-            {/* 테스트용 모달 오픈 버튼들 */}
-            <button
-              className="px-3 py-2 bg-gray-100 rounded-lg text-sm hover:bg-gray-200"
-              onClick={() => openCommentModal(1)}
-            >
-              모달 테스트(코멘트)
-            </button>
-            <button
-              className="px-3 py-2 bg-gray-100 rounded-lg text-sm hover:bg-gray-200"
-              onClick={() => openCreateGroupModal()}
-            >
-              모달 테스트(그룹 생성)
-            </button>
-            <button
-              className="px-3 py-2 bg-gray-100 rounded-lg text-sm hover:bg-gray-200"
-              onClick={() => openModifyGroupModal()}
-            >
-              모달 테스트(그룹 수정)
-            </button>
-            <div className="flex space-x-2">
-              <div className="w-8 h-8 bg-pink-400 rounded-full"></div>
-              <div className="w-8 h-8 bg-orange-400 rounded-full"></div>
-              <div className="w-8 h-8 bg-green-400 rounded-full"></div>
-              <div className="w-8 h-8 bg-purple-400 rounded-full"></div>
-              <div className="w-8 h-8 bg-pink-400 rounded-full"></div>
-              <div className="w-8 h-8 bg-orange-400 rounded-full"></div>
-            </div>
-          </div>
-        </div>
+        <PlanHeader projectName={projectInfo?.title || ""} />
 
         {/* 좌측 패널과 중간 패널 컨테이너 */}
         <div className="flex flex-1 min-h-0">
@@ -59,9 +24,11 @@ const Plan = () => {
           </div>
 
           {/* 중간 패널 - 여행 일정 */}
-          <div className={`relative w-[29.167%] h-full bg-white border-r border-gray-200 ${
-            activeModal === null ? "overflow-y-auto" : "overflow-y-hidden"
-          }`}>
+          <div
+            className={`relative w-[29.167%] h-full bg-white border-r border-gray-200 ${
+              activeModal === null ? "overflow-y-auto" : "overflow-y-hidden"
+            }`}
+          >
             {activeModal === "comment" && <CommentSheet />}
             <div className="p-5">
               <h2 className="text-lg font-medium text-gray-800 mb-2">


### PR DESCRIPTION
## 📌 PR 제목

feat: Plan 페이지 헤더 구현 - #49

## 📍 PR 내용

Plan 페이지 헤더 부분 구현했습니다.

## 📎 관련 이슈
- close #49 

## 💡 테스트 방법
<!-- 기능 테스트 방법 작성 -->
1. 
2. 

---

## 📷 스크린샷(선택)
<!-- 필요 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 플랜 화면 상단에 새로운 헤더 도입: 뒤로가기 아이콘, 프로젝트명 표시, 사용자 섹션, 초대 버튼 포함.
  - 프로젝트 정보와 실시간 참여자 목록을 불러오는 기능 추가로 헤더에 동적 데이터 반영.
  - 초대 버튼 클릭 시 미구현 안내 메시지 알림 제공.

- 리팩터링
  - 플랜 페이지의 기존 인라인 헤더를 모듈화된 헤더 컴포넌트로 교체하여 구조 개선.
  - 임시 초대/테스트 관련 버튼과 모달 요소 제거로 인터페이스 간소화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->